### PR TITLE
fix results table overflow issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added Craft 4 compatibility.
+- Fixed a bug where the query results table could overflow the content pane. ([#30](https://github.com/craftcms/query/pull/30))
 
 ## 3.0.0 - 2022-05-03
 

--- a/src/templates/_index.html
+++ b/src/templates/_index.html
@@ -21,4 +21,4 @@
   </div>
 </form>
 
-<div id="query-result" class="field"></div>
+<div id="query-result" class="field tablepane"></div>


### PR DESCRIPTION
### Description
Fixes the results table overflow spill by allowing the table to scroll horizontally.

Before:
<img width="1302" alt="Screenshot 2024-03-19 at 10 34 32" src="https://github.com/craftcms/query/assets/4500340/1be7dedf-7cb6-4df0-aeff-ada971b68bcb">

After:
<img width="1279" alt="Screenshot 2024-03-19 at 10 34 19" src="https://github.com/craftcms/query/assets/4500340/04fbdba6-ad3c-428b-8c04-f1ef39214c2c">

(Tested against craft v4 and v5.)

### Related issues
n/a
